### PR TITLE
Fix missing tablelib inclusion

### DIFF
--- a/classes/table/detail.php
+++ b/classes/table/detail.php
@@ -29,6 +29,8 @@ if (!defined('MOODLE_INTERNAL')) {
     die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.
 }
 
+require_once($CFG->libdir.'/tablelib.php');
+
 use moodle_url;
 use stdClass;
 use table_sql;

--- a/classes/table/history.php
+++ b/classes/table/history.php
@@ -29,6 +29,8 @@ if (!defined('MOODLE_INTERNAL')) {
     die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.
 }
 
+require_once($CFG->libdir.'/tablelib.php');
+
 use html_writer;
 use moodle_url;
 use stdClass;


### PR DESCRIPTION
The class table_sql is not covered by the Moodle auto-loading mechanism.

Fixes bug #15