### PR TITLE
Add missing index to schema and upgrade script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ cache:
 php:
   - 5.5
   - 7.0
+  - 7.1
 
 addons:
   postgresql: "9.4"
@@ -50,6 +51,10 @@ matrix:
     - php: 5.5
       env: DB=pgsql MOODLE_BRANCH=master CI_PLUGIN=2
     - php: 7.0
+      env: DB=mysqli MOODLE_BRANCH=master CI_PLUGIN=2
+    - php: 7.0
+      env: DB=pgsql MOODLE_BRANCH=master CI_PLUGIN=2
+    - php: 7.0
       env: DB=mysqli MOODLE_BRANCH=MOODLE_27_STABLE
     - php: 7.0
       env: DB=pgsql MOODLE_BRANCH=MOODLE_27_STABLE
@@ -57,6 +62,22 @@ matrix:
       env: DB=mysqli MOODLE_BRANCH=MOODLE_29_STABLE
     - php: 7.0
       env: DB=pgsql MOODLE_BRANCH=MOODLE_29_STABLE
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_27_STABLE
+    - php: 7.1
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_27_STABLE
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_29_STABLE
+    - php: 7.1
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_29_STABLE
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_30_STABLE
+    - php: 7.1
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_30_STABLE
+    - php: 7.1
+      env: DB=mysqli MOODLE_BRANCH=MOODLE_31_STABLE
+    - php: 7.1
+      env: DB=pgsql MOODLE_BRANCH=MOODLE_31_STABLE
 
 before_install:
   - phpenv config-rm xdebug.ini

--- a/db/install.xml
+++ b/db/install.xml
@@ -7,7 +7,7 @@
     <TABLE NAME="tool_lockstats_locks" COMMENT="Table to store current locks">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="task" TYPE="char" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="task" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="gained" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="released" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="host" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
@@ -24,7 +24,7 @@
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="taskid" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="task" TYPE="char" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="task" TYPE="char" LENGTH="255" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="gained" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="released" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="duration" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>

--- a/db/install.xml
+++ b/db/install.xml
@@ -7,7 +7,7 @@
     <TABLE NAME="tool_lockstats_locks" COMMENT="Table to store current locks">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
-        <FIELD NAME="task" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="task" TYPE="char" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="gained" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="released" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="host" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
@@ -16,12 +16,15 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="task" UNIQUE="false" FIELDS="task"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="tool_lockstats_history" COMMENT="Historic log of locked tasks.">
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true"/>
         <FIELD NAME="taskid" TYPE="int" LENGTH="20" NOTNULL="true" SEQUENCE="false"/>
-        <FIELD NAME="task" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="task" TYPE="char" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="gained" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="released" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="duration" TYPE="int" LENGTH="20" NOTNULL="false" SEQUENCE="false"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -1,0 +1,51 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * DB upgrades for tool_lockstats.
+ *
+ * @package    tool_lockstats
+ * @author     Trisha Milan <trishamilan@catalyst-au.net>
+ * @copyright  2019 Catalyst IT
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+function xmldb_tool_lockstats_upgrade($oldversion) {
+    global $DB;
+
+    $dbman = $DB->get_manager();
+
+    if ($oldversion < 2019011600) {
+        $lockstable = new xmldb_table('tool_lockstats_locks');
+        $historytable = new xmldb_table('tool_lockstats_history');
+
+        $field = new xmldb_field('task', XMLDB_TYPE_CHAR);
+        // Update task column to use CHAR instead of TEXT.
+        $dbman->change_field_type($lockstable, $field, $continue = true, $feedback = true);
+        $dbman->change_field_type($historytable, $field, $continue = true, $feedback = true);
+
+        $index = new xmldb_index('task', XMLDB_INDEX_NOTUNIQUE, array('task'));
+        // Conditionally launch add index.
+        if (!$dbman->index_exists($lockstable, $index)) {
+            $dbman->add_index($lockstable, $index);
+        }
+        upgrade_plugin_savepoint(true, 2019011600, 'tool', 'lockstats');
+    }
+
+    return true;
+}

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -34,7 +34,8 @@ function xmldb_tool_lockstats_upgrade($oldversion) {
         $lockstable = new xmldb_table('tool_lockstats_locks');
         $historytable = new xmldb_table('tool_lockstats_history');
 
-        $field = new xmldb_field('task', XMLDB_TYPE_CHAR);
+        $field = new xmldb_field('task');
+        $field->set_attributes(XMLDB_TYPE_CHAR, '255', null, null, null, null);
         // Update task column to use CHAR instead of TEXT.
         $dbman->change_field_type($lockstable, $field, $continue = true, $feedback = true);
         $dbman->change_field_type($historytable, $field, $continue = true, $feedback = true);

--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@ if (!defined('MOODLE_INTERNAL')) {
     die('Direct access to this script is forbidden.'); // It must be included from a Moodle page.
 }
 
-$plugin->version   = 2017102501;
+$plugin->version   = 2019011600;
 $plugin->release   = 2017031500;
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->requires  = 2014051200; // Moodle 2.7 release and upwards.


### PR DESCRIPTION
This commit will also update the task field on tables 'mdl_tool_lockstats_locks' and 'mdl_tool_lockstats_history' to use CHAR data type instead of TEXT as TEXT can not be indexed.

This fixes #28.