### PR TITLE
Fix#79 Make SQL compatible with MySQL

### DIFF
--- a/classes/table/adhoc_tasks.php
+++ b/classes/table/adhoc_tasks.php
@@ -100,14 +100,13 @@ class adhoc_tasks extends html_table {
 
         $concat = $DB->sql_concat("'adhoc_'", 'ta.id');
         $faildelaysubquery = "
-           SELECT COUNT(ta.*) AS faildelay
+           SELECT COUNT(*) AS faildelay
              FROM {task_adhoc} ta
              JOIN {tool_lockstats_locks} tll ON tll.resourcekey = $concat
             WHERE ta.classname = classes.classname
                   AND ta.faildelay > 0";
-
         $runningsubquery = "
-           SELECT COUNT(ta.*)
+           SELECT COUNT(*)
              FROM {task_adhoc} ta
              JOIN {tool_lockstats_locks} tll ON tll.resourcekey = $concat
             WHERE ta.classname = classes.classname
@@ -135,7 +134,7 @@ class adhoc_tasks extends html_table {
                   component";
 
         $sql = "
-           SELECT DISTINCT ON (classes.classname)
+           SELECT DISTINCT
                   classes.classname,
                   classes.component,
                   ($queuedupsubquery  ) queuedup,


### PR DESCRIPTION
Rewrite the SQL syntax for the Adhoc tasks summary to
for compatiblity with MySQL. Previously it only worked
with a postgres database.

Change-Id: I9a12fb75343b64738bdce3c4c55491e6404f4c15