### PR TITLE
Handle high-concurrecny adhoc tasks better

### DIFF
--- a/classes/proxy_lock_factory.php
+++ b/classes/proxy_lock_factory.php
@@ -246,7 +246,7 @@ class proxy_lock_factory implements lock_factory {
             $record->host = gethostname();
             $record->pid = posix_getpid();
             $record = $this->fill_more_for_tasks($record, $resourcekey);
-            if (isset($timequeued) && $timequeued->nextruntime > 0) {
+            if (!empty($timequeued) && $timequeued->nextruntime > 0) {
                 $record->latency = $record->gained - $timequeued->nextruntime;
             } else {
                 $record->latency = 0;
@@ -258,7 +258,7 @@ class proxy_lock_factory implements lock_factory {
             $record->released = null;
             $record->host = gethostname();
             $record->pid = posix_getpid();
-            if (isset($timequeued) && $timequeued->nextruntime > 0) {
+            if (!empty($timequeued) && $timequeued->nextruntime > 0) {
                 $record->latency = $record->gained - $timequeued->nextruntime;
             }
 
@@ -442,11 +442,11 @@ class proxy_lock_factory implements lock_factory {
 
         $adhocid = \tool_lockstats\table\locks::get_adhoc_id_by_task($resourcekey);
         if ($adhocid != null) {
-            $adhocparams = ['id' => $adhocid];
-            $adhocselect = $DB->sql_compare_text('id') . ' = ' . $DB->sql_compare_text(':id');
-            $adhocrecord = $DB->get_record_select('task_adhoc', $adhocselect, $adhocparams);
-            $record->classname = $adhocrecord->classname;
-            $record->customdata = $adhocrecord->customdata;
+            if ($adhocrecord = $DB->get_record('task_adhoc', ['id' => $adhocid])) {
+                // The task could have been picked up already.
+                $record->classname = $adhocrecord->classname;
+                $record->customdata = $adhocrecord->customdata;
+            }
         } else {
             $scheduledparams = ['classname' => $resourcekey];
             $scheduledselect = $DB->sql_compare_text('classname') . ' = ' . $DB->sql_compare_text(':classname');


### PR DESCRIPTION
When running high numbers of adhoc tasks on a fast system with multiple
cron runners and after the implementation of MDL-67596, it's quite
possible for a task to be looked at by multiple runners because the task
still exists in the database at the time that the runner starts to
request a new task.

This is harmless enough because they fail to acquire a lock and continue
to look at the next task.

However, when a task finishes running it removes the record.
When the runner fetches a list on a busy system, it may encounter a
number of tasks which are still in-progress, and then get to a
shorter-lived task which is no longer in progress and has now been
removed from the database.

However the lockstats plugin makes the assumption that the adhoc task
record still exists.