### PR TITLE
Issue #89: Added fallback display to history table

### DIFF
--- a/classes/table/history.php
+++ b/classes/table/history.php
@@ -147,22 +147,35 @@ class history extends table_sql {
      * @return string
      */
     public function col_classname($values) {
-
+        global $DB;
         if ($this->is_downloading()) {
             return $values->taskid;
         }
 
-        $url = new moodle_url("/admin/tool/lockstats/detail.php", [
-            'task' => $values->taskid,
-            'tsort' => 'duration',
-        ]);
+        // Classname can occasionally be empty from adhoc tasks.
+        if (empty($values->classname)) {
+            // If there is no class information, use a normalised resource key for the lock.
+            $resourcekey = $DB->get_field('tool_lockstats_locks', 'resourcekey', ['id' => $values->taskid]);
+            if ($resourcekey !== false && !empty($resourcekey)) {
+                return $resourcekey;
+            } else {
+                // If the lock record is missing, display a message.
+                return get_string('table_missinglock', 'tool_lockstats');
+            }
+        } else {
+            $url = new moodle_url("/admin/tool/lockstats/detail.php", [
+                'task' => $values->taskid,
+                'tsort' => 'duration',
+            ]);
 
-        $classname = explode("\\", $values->classname);
-        $link = ucwords(str_replace("_", " ", end($classname)));
-        $link = html_writer::link($url, $link)
-            . "\n" . html_writer::tag('span', $values->classname, ['class' => 'task-class']);
+            $classname = explode("\\", $values->classname);
+            $link = ucwords(str_replace("_", " ", end($classname)));
+            $link = html_writer::link($url, $link)
+                . "\n" . html_writer::tag('span', $values->classname, ['class' => 'task-class']);
 
-        return $link;
+            return $link;
+        }
+
     }
 
 }

--- a/lang/en/tool_lockstats.php
+++ b/lang/en/tool_lockstats.php
@@ -70,5 +70,6 @@ $string['table_running'] = 'Running';
 $string['table_failed'] = 'Failed';
 $string['task_cleanup'] = 'Cleanup lockstats history';
 $string['table_latency'] = 'Latency';
+$string['table_missinglock'] = 'Unable to find matching lock record.';
 $string['threshold'] = 'History threshold';
 $string['thresholddesc'] = 'Only log new history entries when the cron task time exceeds this value.';


### PR DESCRIPTION
 Closes #89 
I did a little digging into a productions system where this issue is present. It seems to occur primarily from the 'Build course cache' adhoc task, but the classname and component don't seem to be recorded by lockstats. The fix in this PR now records the classname for locks that arent related to a task (adhoc or scheduled), and gives some information on the lock, such as originating class/function, or file/line, or in the worst case, shows a record relating empty entries to missing lock entries in the locks table