### PR TITLE
Moodle 310 stable 500 runtests

### DIFF
--- a/tests/adhoc_tasks_test.php
+++ b/tests/adhoc_tasks_test.php
@@ -36,7 +36,7 @@ if (!defined('MOODLE_INTERNAL')) {
  * @copyright  2020 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class adhoc_tasks_table_testcase extends advanced_testcase {
+class adhoc_tasks_test extends advanced_testcase {
     public function test_history_table_constructor() {
         // This function tests the constructor for the history table for Cross DB compatability.
         // This test contains no assertions, but ensures there are no exceptions.

--- a/tests/proxy_lock_test.php
+++ b/tests/proxy_lock_test.php
@@ -36,7 +36,7 @@ if (!defined('MOODLE_INTERNAL')) {
  * @copyright  2017 Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class proxy_lock_testcase extends advanced_testcase {
+class proxy_lock_test extends advanced_testcase {
     /**
      * Clean up the database.
      */

--- a/tests/proxy_lock_test.php
+++ b/tests/proxy_lock_test.php
@@ -45,7 +45,7 @@ class proxy_lock_testcase extends advanced_testcase {
 
         $dbtype = clean_param($DB->get_dbfamily(), PARAM_ALPHA);
 
-        $lockfactoryclass = "\\core\\lock\\${dbtype}_lock_factory";
+        $lockfactoryclass = "\\core\\lock\\{$dbtype}_lock_factory";
         if (!class_exists($lockfactoryclass)) {
             $lockfactoryclass = '\core\lock\file_lock_factory';
         }

--- a/tests/stale_lock_test.php
+++ b/tests/stale_lock_test.php
@@ -24,7 +24,7 @@ namespace tool_lockstats\test;
  * @copyright  Catalyst IT
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class stale_lock_testcase extends \advanced_testcase {
+class stale_lock_test extends \advanced_testcase {
     public function test_lock_staleness() {
         global $DB;
         $this->resetAfterTest();


### PR DESCRIPTION
For runtests in Moodle 5.0
Resolves "Class … could not be found" error
Resolves "Using ${var} in strings is deprecated, use {$var} instead" php deprecation